### PR TITLE
Added async option to your $.ajax call

### DIFF
--- a/jquery.jsonrpc.js
+++ b/jquery.jsonrpc.js
@@ -167,6 +167,7 @@
         var _that = this;
         $.ajax({
           type: 'POST',
+          async: false !== options.async,
           dataType: 'json',
           contentType: 'application/json',
           url: this._requestUrl(options.url),


### PR DESCRIPTION
I had a need to turn off async for various calls in what I'm doing and really didn't want to modify too much of your code, nor did I want to allow for more options to be passed into $.ajax at this time. 

Just a one-liner, looks in options for the flag.
