### PR TITLE
Normalize documentation, Add 'undefined' variable, Make 'tm' GET parameter configurable

### DIFF
--- a/jquery.jsonrpc.js
+++ b/jquery.jsonrpc.js
@@ -199,7 +199,7 @@
       // Determines the appropriate request URL to call for a request
       _requestUrl: function(url, cache) {
         url = url || this.endPoint;
-        if (cache) {
+        if (!cache) {
             url += '?tm=' + new Date().getTime();
         }
         return url;


### PR DESCRIPTION
I noticed that jquery-jsonrpc adds an extra 'tm' GET parameter to every request. Since POST requests are not cached, unless the endpoint explicitly sets cache headers, this should never be necessary.

the $.ajax cache option already includes code to set an extra GET parameter to disable caching, but does not use this for POST requests. I think the GET parameter thing could be removed altogether as it barely provides any benefit. For now I made it configurable and set the cache option to true (thus disabling the extra GET parameter). The name of the option is a bit misleading as cache=True does not mean that the request should be cached, but that extra GET parameters should be sent along to disable caching. I just adopted the naming of jQuery.

If one desperately want an extra GET parameter one can always overwrite the URL every request or write a special function which does that. Having this in the code of jquery-jsonrpc just feels wrong to me.
