### PR TITLE
Better error handling

### DIFF
--- a/jquery.jsonrpc.js
+++ b/jquery.jsonrpc.js
@@ -205,7 +205,11 @@
       // Handles calling of error callback function
       _requestError: function(json, error) {
         if (typeof(error) !== 'undefined' && typeof(error) === 'function') {
-            error(this._response());
+            if(typeof(json.responseText) === 'string') {
+                error(eval ( '(' + json.responseText + ')' ));
+            } else {
+                error(this._response());
+            }
         }
       },
 


### PR DESCRIPTION
Hi, I've been using jquery-jsonrpc to do, well, RPC obviously.

However, I was annoyed that error objects could not be accessed. I always just got the generic "internal server error" object that the script itself creates.

This branch works, and it's a very simple fix :)
