### PR TITLE
Bump version number so bower sees manifest

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-jsonrpc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/datagraph/jquery-jsonrpc",
   "description": "A JSON RPC 2.0 client for jQuery",
   "main": "jquery.jsonrpc.js",


### PR DESCRIPTION
Bower is trying to use the 0.1.0 release tag, which doesn't have the manifest.

Could you accept this pull request, create a new 0.1.1 tag and make that tag a release? After that I'll register the package with bower and then it should be all ready to use!
