### PR TITLE
Fixed JSON parsing with eval

### DIFF
--- a/jquery.jsonrpc.js
+++ b/jquery.jsonrpc.js
@@ -269,7 +269,7 @@
         else {
           try {
             if(typeof(json) === 'string') {
-              json = eval ( '(' + json + ')' );
+              json = JSON.parse(json);
             }
 
             if (($.isArray(json) && json.length > 0 && json[0].jsonrpc !== '2.0') ||

--- a/jquery.jsonrpc.js
+++ b/jquery.jsonrpc.js
@@ -228,7 +228,7 @@
         if (error !== undefined && typeof(error) === 'function') {
           if(typeof(json.responseText) === 'string') {
             try {
-              error(eval ( '(' + json.responseText + ')' ));
+              error(JSON.parse(json.responseText));
             }
             catch(e) {
               error(this._response());


### PR DESCRIPTION
Please never use `eval` to parse JSON data. 

JSON is not JavaScript, but a subset of the object literal notation from there.

I know using `eval` works, but better solutions exist, and browsers have [supported them for ages](http://caniuse.com/#feat=json).
